### PR TITLE
Needless condition

### DIFF
--- a/app/views/shared/_obj.html.haml
+++ b/app/views/shared/_obj.html.haml
@@ -7,7 +7,6 @@
         = raw @seo_page.page_content
     - else
       = raw obj.content
-    - if !obj.nil?
       = render 'shared/admin_link', obj: obj
     - if !@seo_page.nil? && (@seo_page.id != obj.id || @seo_page.class.name != obj.class.name)
       = render 'shared/admin_link', obj: @seo_page


### PR DESCRIPTION
!obj.nil? is always true here, because condition inside unless obj.nil?